### PR TITLE
Fix printSample which printed target value t instead of predicted value y

### DIFF
--- a/notebooks/RNN_implementation/rnn_implementation_part02.ipynb
+++ b/notebooks/RNN_implementation/rnn_implementation_part02.ipynb
@@ -145,7 +145,7 @@
     "    print('      -------   --')\n",
     "    print('t:  = {:s}   {:2d}'.format(t, int(''.join(reversed(t)), 2)))\n",
     "    if not y is None:\n",
-    "        print('y:  = {:s}'.format(t))\n",
+    "        print('y:  = {:s}'.format(y))\n",
     "    \n",
     "# Print the first sample\n",
     "printSample(X_train[0,:,0], X_train[0,:,1], T_train[0,:,:])"


### PR DESCRIPTION
This is minor fix for printSample function.
The function printed target value t instead of predicted value y.
As a result, the RNN looks always returning correct answer even for very small training examples.

Thanks!